### PR TITLE
Section Break inspector implementation

### DIFF
--- a/inspectors/inspectors_resources.qrc
+++ b/inspectors/inspectors_resources.qrc
@@ -92,5 +92,6 @@
         <file>view/qml/common/StyledIconLabel.qml</file>
         <file>resources/icons/orientation_auto.svg</file>
         <file>view/qml/notation/barlines/BarlinePopup.qml</file>
+        <file>view/qml/notation/sectionbreaks/SectionBreakPopup.qml</file>
     </qresource>
 </RCC>

--- a/inspectors/models/abstractinspectormodel.cpp
+++ b/inspectors/models/abstractinspectormodel.cpp
@@ -47,6 +47,7 @@ AbstractInspectorModel::InspectorSectionType AbstractInspectorModel::modelTypeFr
     case Ms::ElementType::GLISSANDO_SEGMENT:
     case Ms::ElementType::TEMPO_TEXT:
     case Ms::ElementType::FERMATA:
+    case Ms::ElementType::LAYOUT_BREAK:
         return SECTION_NOTATION;
 
     default:

--- a/inspectors/models/abstractinspectormodel.cpp
+++ b/inspectors/models/abstractinspectormodel.cpp
@@ -1,4 +1,5 @@
 #include "abstractinspectormodel.h"
+#include "global/log.h"
 
 AbstractInspectorModel::AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository)
     : QObject(parent)
@@ -84,12 +85,19 @@ void AbstractInspectorModel::onPropertyValueChanged(const Ms::Pid pid, const QVa
         return;
 
     Ms::Score* score  = parentScore();
+    IF_ASSERT_FAILED(score) {
+        return;
+    }
+    
     score->startCmd();
 
     QVariant convertedValue;
 
     for (Ms::Element* element : m_elementList) {
-
+        IF_ASSERT_FAILED(element) {
+            continue;
+        }
+        
         Ms::PropertyFlags ps = element->propertyFlags(pid);
 
         if (ps == Ms::PropertyFlags::STYLED)
@@ -134,14 +142,17 @@ void AbstractInspectorModel::onResetToDefaults(const QList<Ms::Pid>& pidList)
         return;
 
     Ms::Score* score  = parentScore();
-
-    if (!score)
+    IF_ASSERT_FAILED(score) {
         return;
+    }
 
     score->startCmd();
 
     for (Ms::Element* element : m_elementList) {
-
+        IF_ASSERT_FAILED(element) {
+            continue;
+        }
+        
         for (const Ms::Pid pid : pidList)
             element->elementBase()->undoResetProperty(pid);
     }
@@ -150,7 +161,11 @@ void AbstractInspectorModel::onResetToDefaults(const QList<Ms::Pid>& pidList)
 
     emit elementsModified();
 
-    m_elementList.at(0)->triggerLayout();
+    auto firstElement = m_elementList.at(0);
+    IF_ASSERT_FAILED(firstElement) {
+        return;
+    }
+    firstElement->triggerLayout();
 
     emit modelReseted();
 }
@@ -278,7 +293,10 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, std::f
     bool isUndefined = false;
 
     for (const Ms::Element* element : m_elementList) {
-
+        IF_ASSERT_FAILED(element) {
+            continue;
+        }
+        
         QVariant elementCurrentValue = valueFromElementUnits(pid, element->getProperty(pid), element);
         QVariant elementDefaultValue = valueFromElementUnits(pid, element->propertyDefault(pid), element);
 
@@ -326,5 +344,10 @@ Ms::Score* AbstractInspectorModel::parentScore() const
         return nullptr;
     }
 
-    return m_elementList.at(0)->score();
+    auto firstElement = m_elementList.at(0);
+    IF_ASSERT_FAILED(firstElement) {
+        return nullptr;
+    }
+    
+    return firstElement->score();
 }

--- a/inspectors/models/abstractinspectormodel.h
+++ b/inspectors/models/abstractinspectormodel.h
@@ -35,7 +35,8 @@ public:
         TYPE_TEMPO,
         TYPE_GLISSANDO,
         TYPE_BARLINE,
-        TYPE_STAFF
+        TYPE_STAFF,
+        TYPE_SECTIONBREAK
     };
 
     explicit AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository = nullptr);

--- a/inspectors/models/notation/notationsettingsproxymodel.cpp
+++ b/inspectors/models/notation/notationsettingsproxymodel.cpp
@@ -12,6 +12,7 @@ NotationSettingsProxyModel::NotationSettingsProxyModel(QObject* parent, IElement
     setGlissandoSettingsModel(new GlissandoSettingsModel(this, repository));
     setBarlineSettingsModel(new BarlineSettingsModel(this, repository));
     setStaffSettingsModel(new StaffSettingsModel(this, repository));
+    setSectionBreakSettingsModel(new SectionBreakSettingsModel(this, repository));
 }
 
 bool NotationSettingsProxyModel::hasAcceptableElements() const
@@ -49,6 +50,11 @@ QObject* NotationSettingsProxyModel::staffSettingsModel() const
     return m_staffSettingsModel;
 }
 
+QObject* NotationSettingsProxyModel::sectionBreakSettingsModel() const
+{
+    return m_sectionBreakSettingsModel;
+}
+
 void NotationSettingsProxyModel::setNoteSettingsModel(NoteSettingsProxyModel* noteSettingsModel)
 {
     m_noteSettingsModel = noteSettingsModel;
@@ -77,4 +83,9 @@ void NotationSettingsProxyModel::setBarlineSettingsModel(BarlineSettingsModel* b
 void NotationSettingsProxyModel::setStaffSettingsModel(StaffSettingsModel* staffSettingsModel)
 {
     m_staffSettingsModel = staffSettingsModel;
+}
+
+void NotationSettingsProxyModel::setSectionBreakSettingsModel(SectionBreakSettingsModel* sectionBreakSettingsModel)
+{
+    m_sectionBreakSettingsModel = sectionBreakSettingsModel;
 }

--- a/inspectors/models/notation/notationsettingsproxymodel.h
+++ b/inspectors/models/notation/notationsettingsproxymodel.h
@@ -9,6 +9,7 @@
 #include "glissandos/glissandosettingsmodel.h"
 #include "barlines/barlinesettingsmodel.h"
 #include "staffs/staffsettingsmodel.h"
+#include "sectionbreaks/sectionbreaksettingsmodel.h"
 
 class NotationSettingsProxyModel : public AbstractInspectorModel
 {
@@ -20,6 +21,8 @@ class NotationSettingsProxyModel : public AbstractInspectorModel
     Q_PROPERTY(QObject* glissandoSettingsModel READ glissandoSettingsModel CONSTANT)
     Q_PROPERTY(QObject* barlineSettingsModel READ barlineSettingsModel CONSTANT)
     Q_PROPERTY(QObject* staffSettingsModel READ staffSettingsModel CONSTANT)
+    Q_PROPERTY(QObject* sectionBreakSettingsModel READ sectionBreakSettingsModel CONSTANT)
+
 public:
     explicit NotationSettingsProxyModel(QObject* parent, IElementRepositoryService* repository);
 
@@ -36,6 +39,7 @@ public:
     QObject* glissandoSettingsModel() const;
     QObject* barlineSettingsModel() const;
     QObject* staffSettingsModel() const;
+    QObject* sectionBreakSettingsModel() const;
 
 public slots:
     void setNoteSettingsModel(NoteSettingsProxyModel* noteSettingsModel);
@@ -44,6 +48,7 @@ public slots:
     void setGlissandoSettingsModel(GlissandoSettingsModel* glissandoSettingsModel);
     void setBarlineSettingsModel(BarlineSettingsModel* barlineSettingsModel);
     void setStaffSettingsModel(StaffSettingsModel* staffSettingsModel);
+    void setSectionBreakSettingsModel(SectionBreakSettingsModel* sectionBreakSettingsModel);
 
 private:
     NoteSettingsProxyModel* m_noteSettingsModel = nullptr;
@@ -52,6 +57,7 @@ private:
     GlissandoSettingsModel* m_glissandoSettingsModel = nullptr;
     BarlineSettingsModel* m_barlineSettingsModel = nullptr;
     StaffSettingsModel* m_staffSettingsModel = nullptr;
+    SectionBreakSettingsModel* m_sectionBreakSettingsModel = nullptr;
 };
 
 #endif // NOTATIONSETTINGSPROXYMODEL_H

--- a/inspectors/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
+++ b/inspectors/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
@@ -1,0 +1,52 @@
+#include "sectionbreaksettingsmodel.h"
+
+SectionBreakSettingsModel::SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository) :
+    AbstractInspectorModel(parent, repository)
+{
+    setModelType(TYPE_SECTIONBREAK);
+    setTitle(tr("Section Break"));
+    createProperties();
+}
+
+void SectionBreakSettingsModel::createProperties()
+{
+    m_startWithLongInstrNames = buildPropertyItem(Ms::Pid::START_WITH_LONG_NAMES);
+    m_resetBarNums = buildPropertyItem(Ms::Pid::START_WITH_MEASURE_ONE);
+    m_pause = buildPropertyItem(Ms::Pid::PAUSE);
+}
+
+void SectionBreakSettingsModel::requestElements()
+{
+    m_elementList = m_repository->findElementsByType(Ms::ElementType::LAYOUT_BREAK);
+}
+
+void SectionBreakSettingsModel::loadProperties()
+{
+    loadPropertyItem(m_startWithLongInstrNames);
+    loadPropertyItem(m_resetBarNums);
+    loadPropertyItem(m_pause, [] (const QVariant& elementPropertyValue) -> QVariant {
+        return QString::number(elementPropertyValue.toDouble(), 'f', 2).toDouble();
+    });
+}
+
+void SectionBreakSettingsModel::resetProperties()
+{
+    m_startWithLongInstrNames->resetToDefault();
+    m_resetBarNums->resetToDefault();
+    m_pause->resetToDefault();
+}
+
+PropertyItem* SectionBreakSettingsModel::startWithLongInstrNames() const
+{
+    return m_startWithLongInstrNames;
+}
+
+PropertyItem* SectionBreakSettingsModel::resetBarNums() const
+{
+    return m_resetBarNums;
+}
+
+PropertyItem* SectionBreakSettingsModel::pause() const
+{
+    return m_pause;
+}

--- a/inspectors/models/notation/sectionbreaks/sectionbreaksettingsmodel.h
+++ b/inspectors/models/notation/sectionbreaks/sectionbreaksettingsmodel.h
@@ -1,0 +1,32 @@
+#ifndef SECTIONBREAKSETTINGSMODEL_H
+#define SECTIONBREAKSETTINGSMODEL_H
+
+#include "models/abstractinspectormodel.h"
+
+class SectionBreakSettingsModel : public AbstractInspectorModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(PropertyItem* startWithLongInstrNames READ startWithLongInstrNames CONSTANT)
+    Q_PROPERTY(PropertyItem* resetBarNums READ resetBarNums CONSTANT)
+    Q_PROPERTY(PropertyItem* pause READ pause CONSTANT)
+
+public:
+    explicit SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    void createProperties() override;
+    void requestElements() override;
+    void loadProperties() override;
+    void resetProperties() override;
+
+    PropertyItem* startWithLongInstrNames() const;
+    PropertyItem* resetBarNums() const;
+    PropertyItem* pause() const;
+
+private:
+    PropertyItem* m_startWithLongInstrNames = nullptr;
+    PropertyItem* m_resetBarNums = nullptr;
+    PropertyItem* m_pause = nullptr;
+};
+
+#endif // SECTIONBREAKSETTINGSMODEL_H

--- a/inspectors/services/elementrepositoryservice.cpp
+++ b/inspectors/services/elementrepositoryservice.cpp
@@ -7,6 +7,7 @@
 #include "glissando.h"
 #include "hairpin.h"
 #include "staff.h"
+#include "layoutbreak.h"
 
 ElementRepositoryService::ElementRepositoryService(QObject* parent) : QObject(parent)
 {
@@ -36,6 +37,7 @@ QList<Ms::Element*> ElementRepositoryService::findElementsByType(const Ms::Eleme
     case Ms::ElementType::GLISSANDO: return findGlissandos();
     case Ms::ElementType::HAIRPIN: return findHairpins();
     case Ms::ElementType::STAFF: return findStaffs();
+    case Ms::ElementType::LAYOUT_BREAK: return findSectionBreaks(); //Page breaks and line breaks are of type LAYOUT_BREAK, but they don't appear in the inspector for now.
     default:
         QList<Ms::Element*> resultList;
 
@@ -225,6 +227,23 @@ QList<Ms::Element*> ElementRepositoryService::findStaffs() const
             continue;
 
         resultList << element->staff();
+    }
+
+    return resultList;
+}
+
+QList<Ms::Element *> ElementRepositoryService::findSectionBreaks() const
+{
+    QList<Ms::Element*> resultList;
+
+    for (Ms::Element* element : m_elementList) {
+        if (element && element->type() == Ms::ElementType::LAYOUT_BREAK) {
+            const Ms::LayoutBreak* layoutBreak = Ms::toLayoutBreak(element);
+            if (layoutBreak->layoutBreakType() != Ms::LayoutBreak::SECTION)
+                continue;
+            
+            resultList << element;
+        }        
     }
 
     return resultList;

--- a/inspectors/services/elementrepositoryservice.h
+++ b/inspectors/services/elementrepositoryservice.h
@@ -33,6 +33,7 @@ private:
     QList<Ms::Element*> findGlissandos() const;
     QList<Ms::Element*> findHairpins() const;
     QList<Ms::Element*> findStaffs() const;
+    QList<Ms::Element*> findSectionBreaks() const;
 };
 
 #endif // ELEMENTREPOSITORYSERVICE_H

--- a/inspectors/view/qml/notation/NotationInspectorView.qml
+++ b/inspectors/view/qml/notation/NotationInspectorView.qml
@@ -8,6 +8,7 @@ import "fermatas"
 import "tempos"
 import "glissandos"
 import "barlines"
+import "sectionbreaks"
 
 FocusableItem {
     id: root
@@ -221,6 +222,44 @@ FocusableItem {
 
                 barlineSettingsModel: root.model ? root.model.barlineSettingsModel : null
                 staffSettingsModel: root.model ? root.model.staffSettingsModel : null
+            }
+        }
+
+        FlatButton {
+            id: sectionBreakSettingsButton
+
+            icon: IconNameTypes.SECTION_BREAK
+            iconPixelSize: 16
+            text: qsTr("Section break")
+
+            Layout.fillWidth: true
+            Layout.minimumWidth: root.width / 2
+
+            visible: root.model && root.model.sectionBreakSettingsModel ? !root.model.sectionBreakSettingsModel.isEmpty : false
+
+            onVisibleChanged: {
+                if (!visible) {
+                    sectionBreakPopup.close()
+                }
+            }
+
+            onClicked: {
+                if (!sectionBreakPopup.isOpened) {
+                    sectionBreakPopup.open()
+                } else {
+                    sectionBreakPopup.close()
+                }
+            }
+
+            SectionBreakPopup {
+                id: sectionBreakPopup
+
+                x: mapToGlobal(grid.x, grid.y).x - mapToGlobal(parent.x, parent.y).x
+                y: parent.height
+                arrowX: parent.x + parent.width / 2
+                width: root.width
+
+                model: root.model ? root.model.sectionBreakSettingsModel : null
             }
         }
     }

--- a/inspectors/view/qml/notation/sectionbreaks/SectionBreakPopup.qml
+++ b/inspectors/view/qml/notation/sectionbreaks/SectionBreakPopup.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import MuseScore.Inspectors 3.3
+import "../../common"
+
+StyledPopup {
+    id: root
+
+    property QtObject model: null
+
+    implicitHeight: contentColumn.implicitHeight + topPadding + bottomPadding
+    width: parent.width
+
+    Column {
+        id: contentColumn
+
+        width: parent.width
+
+        spacing: 12
+
+        Column {
+            width: parent.width
+            spacing: 8
+
+            StyledTextLabel {
+                text: qsTr("Pause before new section starts")
+            }
+
+            IncrementalPropertyControl {
+                isIndeterminate: model ? model.pause.isUndefined : false
+                currentValue: model ? model.pause.value : 0
+                iconMode: iconModeEnum.hidden
+                maxValue: 999
+                minValue: 0
+                step: 0.5
+                measureUnitsSymbol: qsTr("s")
+
+                onValueEdited: { model.pause.value = newValue }
+            }
+        }
+
+        CheckBox {
+            id: showLongInstrNameCheckbox
+
+            isIndeterminate: model ? model.startWithLongInstrNames.isUndefined : false
+            checked: model && !isIndeterminate ? model.startWithLongInstrNames.value : false
+            text: qsTr("Start new section with long instrument names")
+
+            onClicked: { model.startWithLongInstrNames.value = !checked }
+        }
+
+        CheckBox {
+            id: resetBarNumsCheckbox
+
+            isIndeterminate: model ? model.resetBarNums.isUndefined : false
+            checked: model && !isIndeterminate ? model.resetBarNums.value : false
+            text: qsTr("Reset bar numbers for new section")
+
+            onClicked: { model.resetBarNums.value = !checked }
+        }
+    }
+}


### PR DESCRIPTION
Should appear on Section Breaks only (not Page or Line breaks).

<img width="442" alt="Screenshot 2020-05-04 at 10 33 30" src="https://user-images.githubusercontent.com/18065034/80948582-b4043c80-8df2-11ea-8300-b141029e35ed.png">
