### PR TITLE
Implemented Articulation and Ornament popups

### DIFF
--- a/inspectors/inspectors_resources.qrc
+++ b/inspectors/inspectors_resources.qrc
@@ -146,5 +146,9 @@
         <file>view/qml/notation/frames/TextFrameSettings.qml</file>
         <file>view/qml/notation/frames/VerticalFrameSettings.qml</file>
         <file>view/qml/notation/frames/HorizontalFrameSettings.qml</file>
+        <file>view/qml/notation/articulations/ArticulationSettings.qml</file>
+        <file>view/qml/notation/articulations/ArticulationPopup.qml</file>
+        <file>view/qml/notation/ornaments/OrnamentPopup.qml</file>
+        <file>view/qml/notation/ornaments/OrnamentSettings.qml</file>
     </qresource>
 </RCC>

--- a/inspectors/inspectorssetup.cpp
+++ b/inspectors/inspectorssetup.cpp
@@ -36,11 +36,11 @@ void InspectorsSetup::registerResources()
 #include "utils/doubleinputvalidator.h"
 #include "utils/intinputvalidator.h"
 #include "models/abstractinspectormodel.h"
-#include "types/direction.h"
+#include "types/stemtypes.h"
 #include "types/noteheadtypes.h"
 #include "types/beamtypes.h"
 #include "types/hairpintypes.h"
-#include "types/articulationtypes.h"
+#include "types/ornamenttypes.h"
 #include "types/dynamictypes.h"
 #include "types/glissandotypes.h"
 #include "types/fermatatypes.h"
@@ -53,6 +53,7 @@ void InspectorsSetup::registerResources()
 #include "types/pedaltypes.h"
 #include "types/texttypes.h"
 #include "types/crescendotypes.h"
+#include "types/articulationtypes.h"
 
 void InspectorsSetup::registerQmlTypes()
 {
@@ -63,7 +64,7 @@ void InspectorsSetup::registerQmlTypes()
     qmlRegisterUncreatableType<NoteHeadTypes>("MuseScore.Inspectors", 3, 3, "NoteHead", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<BeamTypes>("MuseScore.Inspectors", 3, 3, "Beam", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<HairpinTypes>("MuseScore.Inspectors", 3, 3, "Hairpin", "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<ArticulationTypes>("MuseScore.Inspectors", 3, 3, "Articulation", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<OrnamentTypes>("MuseScore.Inspectors", 3, 3, "Articulation", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<DynamicTypes>("MuseScore.Inspectors", 3, 3, "Dynamic", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<GlissandoTypes>("MuseScore.Inspectors", 3, 3, "Glissando", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<FermataTypes>("MuseScore.Inspectors", 3, 3, "FermataTypes", "Not creatable as it is an enum type");
@@ -76,4 +77,5 @@ void InspectorsSetup::registerQmlTypes()
     qmlRegisterUncreatableType<PedalTypes>("MuseScore.Inspectors", 3, 3, "PedalTypes", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<TextTypes>("MuseScore.Inspectors", 3, 3, "TextTypes", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<CrescendoTypes>("MuseScore.Inspectors", 3, 3, "CrescendoTypes", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<ArticulationTypes>("MuseScore.Inspectors", 3, 3, "ArticulationTypes", "Not creatable as it is an enum type");
 }

--- a/inspectors/inspectorssetup.cpp
+++ b/inspectors/inspectorssetup.cpp
@@ -64,7 +64,7 @@ void InspectorsSetup::registerQmlTypes()
     qmlRegisterUncreatableType<NoteHeadTypes>("MuseScore.Inspectors", 3, 3, "NoteHead", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<BeamTypes>("MuseScore.Inspectors", 3, 3, "Beam", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<HairpinTypes>("MuseScore.Inspectors", 3, 3, "Hairpin", "Not creatable as it is an enum type");
-    qmlRegisterUncreatableType<OrnamentTypes>("MuseScore.Inspectors", 3, 3, "Articulation", "Not creatable as it is an enum type");
+    qmlRegisterUncreatableType<OrnamentTypes>("MuseScore.Inspectors", 3, 3, "OrnamentTypes", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<DynamicTypes>("MuseScore.Inspectors", 3, 3, "Dynamic", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<GlissandoTypes>("MuseScore.Inspectors", 3, 3, "Glissando", "Not creatable as it is an enum type");
     qmlRegisterUncreatableType<FermataTypes>("MuseScore.Inspectors", 3, 3, "FermataTypes", "Not creatable as it is an enum type");

--- a/inspectors/models/abstractinspectormodel.cpp
+++ b/inspectors/models/abstractinspectormodel.cpp
@@ -14,11 +14,13 @@ static const QList<Ms::ElementType> NOTATION_ELEMENT_TYPES = { Ms::ElementType::
                                                                Ms::ElementType::CLEF, Ms::ElementType::HAIRPIN,
                                                                Ms::ElementType::HAIRPIN_SEGMENT, Ms::ElementType::STAFFTYPE_CHANGE,
                                                                Ms::ElementType::TBOX /*text frame*/, Ms::ElementType::VBOX, /*vertical frame*/
-                                                               Ms::ElementType::HBOX /*horizontal frame*/};
+                                                               Ms::ElementType::HBOX /*horizontal frame*/, Ms::ElementType::ARTICULATION
+                                                             };
 
 static const QList<Ms::ElementType> TEXT_ELEMENT_TYPES = { Ms::ElementType::TEXT, Ms::ElementType::TEXTLINE,
                                                            Ms::ElementType::TEXTLINE_BASE, Ms::ElementType::TEXTLINE_SEGMENT,
-                                                           Ms::ElementType::STAFF_TEXT, Ms::ElementType::SYSTEM_TEXT };
+                                                           Ms::ElementType::STAFF_TEXT, Ms::ElementType::SYSTEM_TEXT
+                                                         };
 
 AbstractInspectorModel::AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository)
     : QObject(parent)

--- a/inspectors/models/abstractinspectormodel.h
+++ b/inspectors/models/abstractinspectormodel.h
@@ -56,7 +56,9 @@ public:
         TYPE_STAFF_TYPE_CHANGES,
         TYPE_TEXT_FRAME,
         TYPE_VERTICAL_FRAME,
-        TYPE_HORIZONTAL_FRAME
+        TYPE_HORIZONTAL_FRAME,
+        TYPE_ARTICULATION,
+        TYPE_ORNAMENT
     };
 
     explicit AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository = nullptr);

--- a/inspectors/models/notation/articulations/articulationsettingsmodel.cpp
+++ b/inspectors/models/notation/articulations/articulationsettingsmodel.cpp
@@ -9,6 +9,17 @@ ArticulationSettingsModel::ArticulationSettingsModel(QObject* parent, IElementRe
     setModelType(TYPE_ARTICULATION);
     setTitle(tr("Articulation"));
     createProperties();
+
+    m_openChannelAndMidiPropertiesAction = Ms::Shortcut::getActionByName("show-articulation-properties");
+}
+
+void ArticulationSettingsModel::openChannelAndMidiProperties()
+{
+    IF_ASSERT_FAILED(m_openChannelAndMidiPropertiesAction) {
+        return;
+    }
+
+    m_openChannelAndMidiPropertiesAction->trigger();
 }
 
 void ArticulationSettingsModel::createProperties()

--- a/inspectors/models/notation/articulations/articulationsettingsmodel.cpp
+++ b/inspectors/models/notation/articulations/articulationsettingsmodel.cpp
@@ -1,0 +1,56 @@
+#include "articulationsettingsmodel.h"
+
+#include "global/log.h"
+#include "articulation.h"
+
+ArticulationSettingsModel::ArticulationSettingsModel(QObject* parent, IElementRepositoryService* repository) :
+    AbstractInspectorModel(parent, repository)
+{
+    setModelType(TYPE_ARTICULATION);
+    setTitle(tr("Articulation"));
+    createProperties();
+}
+
+void ArticulationSettingsModel::createProperties()
+{
+    m_direction = buildPropertyItem(Ms::Pid::DIRECTION);
+    m_placement = buildPropertyItem(Ms::Pid::ARTICULATION_ANCHOR);
+}
+
+void ArticulationSettingsModel::requestElements()
+{
+    m_elementList = m_repository->findElementsByType(Ms::ElementType::ARTICULATION, [] (const Ms::Element* element) -> bool {
+        IF_ASSERT_FAILED(element) {
+            return false;
+        }
+
+        const Ms::Articulation* articulation = Ms::toArticulation(element);
+        IF_ASSERT_FAILED(articulation) {
+            return false;
+        }
+
+        return !articulation->isOrnament();
+    });
+}
+
+void ArticulationSettingsModel::loadProperties()
+{
+    loadPropertyItem(m_direction);
+    loadPropertyItem(m_placement);
+}
+
+void ArticulationSettingsModel::resetProperties()
+{
+    m_direction->resetToDefault();
+    m_placement->resetToDefault();
+}
+
+PropertyItem* ArticulationSettingsModel::direction() const
+{
+    return m_direction;
+}
+
+PropertyItem* ArticulationSettingsModel::placement() const
+{
+    return m_placement;
+}

--- a/inspectors/models/notation/articulations/articulationsettingsmodel.h
+++ b/inspectors/models/notation/articulations/articulationsettingsmodel.h
@@ -3,6 +3,9 @@
 
 #include "models/abstractinspectormodel.h"
 
+#include "shortcut.h"
+#include <QAction>
+
 class ArticulationSettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
@@ -12,6 +15,8 @@ class ArticulationSettingsModel : public AbstractInspectorModel
 
 public:
     explicit ArticulationSettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    Q_INVOKABLE void openChannelAndMidiProperties();
 
     void createProperties() override;
     void requestElements() override;
@@ -24,6 +29,8 @@ public:
 private:
     PropertyItem* m_direction = nullptr;
     PropertyItem* m_placement = nullptr;
+
+    QAction* m_openChannelAndMidiPropertiesAction = nullptr;
 };
 
 #endif // ARTICULATIONSETTINGSMODEL_H

--- a/inspectors/models/notation/articulations/articulationsettingsmodel.h
+++ b/inspectors/models/notation/articulations/articulationsettingsmodel.h
@@ -1,0 +1,29 @@
+#ifndef ARTICULATIONSETTINGSMODEL_H
+#define ARTICULATIONSETTINGSMODEL_H
+
+#include "models/abstractinspectormodel.h"
+
+class ArticulationSettingsModel : public AbstractInspectorModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(PropertyItem* direction READ direction CONSTANT)
+    Q_PROPERTY(PropertyItem* placement READ placement CONSTANT)
+
+public:
+    explicit ArticulationSettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    void createProperties() override;
+    void requestElements() override;
+    void loadProperties() override;
+    void resetProperties() override;
+
+    PropertyItem* direction() const;
+    PropertyItem* placement() const;
+
+private:
+    PropertyItem* m_direction = nullptr;
+    PropertyItem* m_placement = nullptr;
+};
+
+#endif // ARTICULATIONSETTINGSMODEL_H

--- a/inspectors/models/notation/notationsettingsproxymodel.cpp
+++ b/inspectors/models/notation/notationsettingsproxymodel.cpp
@@ -21,6 +21,8 @@
 #include "frames/textframesettingsmodel.h"
 #include "frames/verticalframesettingsmodel.h"
 #include "frames/horizontalframesettingsmodel.h"
+#include "articulations/articulationsettingsmodel.h"
+#include "ornaments/ornamentsettingsmodel.h"
 
 NotationSettingsProxyModel::NotationSettingsProxyModel(QObject* parent, IElementRepositoryService* repository) :
     AbstractInspectorProxyModel(parent)
@@ -49,4 +51,6 @@ NotationSettingsProxyModel::NotationSettingsProxyModel(QObject* parent, IElement
     addModel(new TextFrameSettingsModel(this, repository));
     addModel(new VerticalFrameSettingsModel(this, repository));
     addModel(new HorizontalFrameSettingsModel(this, repository));
+    addModel(new ArticulationSettingsModel(this, repository));
+    addModel(new OrnamentSettingsModel(this, repository));
 }

--- a/inspectors/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/inspectors/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -1,6 +1,6 @@
 #include "stemsettingsmodel.h"
 
-#include "types/direction.h"
+#include "types/stemtypes.h"
 
 StemSettingsModel::StemSettingsModel(QObject *parent, IElementRepositoryService* repository) : AbstractInspectorModel(parent, repository)
 {
@@ -36,7 +36,7 @@ void StemSettingsModel::requestElements()
 
 void StemSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_isStemHidden, [this] (const QVariant& isVisible) -> QVariant {
+    loadPropertyItem(m_isStemHidden, [] (const QVariant& isVisible) -> QVariant {
         return !isVisible.toBool();
     });
 

--- a/inspectors/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/inspectors/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -1,0 +1,56 @@
+#include "ornamentsettingsmodel.h"
+
+#include "global/log.h"
+#include "articulation.h"
+
+OrnamentSettingsModel::OrnamentSettingsModel(QObject* parent, IElementRepositoryService* repository) :
+    AbstractInspectorModel(parent, repository)
+{
+    setModelType(TYPE_ORNAMENT);
+    setTitle(tr("Ornament"));
+    createProperties();
+}
+
+void OrnamentSettingsModel::createProperties()
+{
+    m_performanceType = buildPropertyItem(Ms::Pid::ORNAMENT_STYLE);
+    m_placement = buildPropertyItem(Ms::Pid::ARTICULATION_ANCHOR);
+}
+
+void OrnamentSettingsModel::requestElements()
+{
+    m_elementList = m_repository->findElementsByType(Ms::ElementType::ARTICULATION, [] (const Ms::Element* element) -> bool {
+        IF_ASSERT_FAILED(element) {
+            return false;
+        }
+
+        const Ms::Articulation* articulation = Ms::toArticulation(element);
+        IF_ASSERT_FAILED(articulation) {
+            return false;
+        }
+
+        return articulation->isOrnament();
+    });
+}
+
+void OrnamentSettingsModel::loadProperties()
+{
+    loadPropertyItem(m_performanceType);
+    loadPropertyItem(m_placement);
+}
+
+void OrnamentSettingsModel::resetProperties()
+{
+    m_performanceType->resetToDefault();
+    m_placement->resetToDefault();
+}
+
+PropertyItem* OrnamentSettingsModel::performanceType() const
+{
+    return m_performanceType;
+}
+
+PropertyItem* OrnamentSettingsModel::placement() const
+{
+    return m_placement;
+}

--- a/inspectors/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/inspectors/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -9,6 +9,17 @@ OrnamentSettingsModel::OrnamentSettingsModel(QObject* parent, IElementRepository
     setModelType(TYPE_ORNAMENT);
     setTitle(tr("Ornament"));
     createProperties();
+
+    m_openChannelAndMidiPropertiesAction = Ms::Shortcut::getActionByName("show-articulation-properties");
+}
+
+void OrnamentSettingsModel::openChannelAndMidiProperties()
+{
+    IF_ASSERT_FAILED(m_openChannelAndMidiPropertiesAction) {
+        return;
+    }
+
+    m_openChannelAndMidiPropertiesAction->trigger();
 }
 
 void OrnamentSettingsModel::createProperties()

--- a/inspectors/models/notation/ornaments/ornamentsettingsmodel.h
+++ b/inspectors/models/notation/ornaments/ornamentsettingsmodel.h
@@ -3,6 +3,9 @@
 
 #include "models/abstractinspectormodel.h"
 
+#include "shortcut.h"
+#include <QAction>
+
 class OrnamentSettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
@@ -12,6 +15,8 @@ class OrnamentSettingsModel : public AbstractInspectorModel
 
 public:
     explicit OrnamentSettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    Q_INVOKABLE void openChannelAndMidiProperties();
 
     void createProperties() override;
     void requestElements() override;
@@ -24,6 +29,8 @@ public:
 private:
     PropertyItem* m_performanceType = nullptr;
     PropertyItem* m_placement = nullptr;
+
+    QAction* m_openChannelAndMidiPropertiesAction = nullptr;
 };
 
 #endif // ORNAMENTSETTINGSMODEL_H

--- a/inspectors/models/notation/ornaments/ornamentsettingsmodel.h
+++ b/inspectors/models/notation/ornaments/ornamentsettingsmodel.h
@@ -1,0 +1,29 @@
+#ifndef ORNAMENTSETTINGSMODEL_H
+#define ORNAMENTSETTINGSMODEL_H
+
+#include "models/abstractinspectormodel.h"
+
+class OrnamentSettingsModel : public AbstractInspectorModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(PropertyItem* performanceType READ performanceType CONSTANT)
+    Q_PROPERTY(PropertyItem* placement READ placement CONSTANT)
+
+public:
+    explicit OrnamentSettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    void createProperties() override;
+    void requestElements() override;
+    void loadProperties() override;
+    void resetProperties() override;
+
+    PropertyItem* performanceType() const;
+    PropertyItem* placement() const;
+
+private:
+    PropertyItem* m_performanceType = nullptr;
+    PropertyItem* m_placement = nullptr;
+};
+
+#endif // ORNAMENTSETTINGSMODEL_H

--- a/inspectors/types/articulationtypes.h
+++ b/inspectors/types/articulationtypes.h
@@ -7,11 +7,8 @@ class ArticulationTypes
 {
     Q_GADGET
 
-    Q_ENUMS(Placement)
-    Q_ENUMS(Direction)
-
 public:
-    enum Placement {
+    enum class Placement {
         TYPE_ABOVE_STAFF,
         TYPE_BELOW_STAFF,
         TYPE_CHORD_AUTO,
@@ -19,11 +16,14 @@ public:
         TYPE_BELOW_CHORD
     };
 
-    enum Direction {
+    enum class Direction {
         AUTO,
         DOWN,
         UP
     };
+
+    Q_ENUM(Placement)
+    Q_ENUM(Direction)
 };
 
 #endif // ARTICULATIONTYPES_H

--- a/inspectors/types/articulationtypes.h
+++ b/inspectors/types/articulationtypes.h
@@ -7,11 +7,22 @@ class ArticulationTypes
 {
     Q_GADGET
 
-    Q_ENUMS(Style)
+    Q_ENUMS(Placement)
+    Q_ENUMS(Direction)
+
 public:
-    enum Style {
-        STYLE_STANDART = 0,
-        STYLE_BAROQUE
+    enum Placement {
+        TYPE_ABOVE_STAFF,
+        TYPE_BELOW_STAFF,
+        TYPE_CHORD_AUTO,
+        TYPE_ABOVE_CHORD,
+        TYPE_BELOW_CHORD
+    };
+
+    enum Direction {
+        AUTO,
+        DOWN,
+        UP
     };
 };
 

--- a/inspectors/types/ornamenttypes.h
+++ b/inspectors/types/ornamenttypes.h
@@ -7,12 +7,13 @@ class OrnamentTypes
 {
     Q_GADGET
 
-    Q_ENUMS(Style)
 public:
-    enum Style {
-        STYLE_STANDART = 0,
+    enum class Style {
+        STYLE_STANDARD = 0,
         STYLE_BAROQUE
     };
+
+    Q_ENUM(Style)
 };
 
 #endif // ORNAMENTTYPES_H

--- a/inspectors/types/ornamenttypes.h
+++ b/inspectors/types/ornamenttypes.h
@@ -1,0 +1,18 @@
+#ifndef ORNAMENTTYPES_H
+#define ORNAMENTTYPES_H
+
+#include "qobjectdefs.h"
+
+class OrnamentTypes
+{
+    Q_GADGET
+
+    Q_ENUMS(Style)
+public:
+    enum Style {
+        STYLE_STANDART = 0,
+        STYLE_BAROQUE
+    };
+};
+
+#endif // ORNAMENTTYPES_H

--- a/inspectors/types/stemtypes.h
+++ b/inspectors/types/stemtypes.h
@@ -1,5 +1,5 @@
-#ifndef DIRECTION_H
-#define DIRECTION_H
+#ifndef STEMTYPES_H
+#define STEMTYPES_H
 
 #include "qobjectdefs.h"
 
@@ -16,4 +16,4 @@ public:
     };
 };
 
-#endif // DIRECTION_H
+#endif // STEMTYPES_H

--- a/inspectors/view/qml/notation/NotationInspectorView.qml
+++ b/inspectors/view/qml/notation/NotationInspectorView.qml
@@ -21,6 +21,8 @@ import "hairpins"
 import "crescendos"
 import "stafftype"
 import "frames"
+import "articulations"
+import "ornaments"
 
 InspectorSectionView {
     id: root
@@ -176,6 +178,20 @@ InspectorSectionView {
             popupPositionX: mapToGlobal(grid.x, grid.y).x - mapToGlobal(x, y).x
             popupAvailableWidth: root.width
             model: root.model ? root.model.modelByType(Inspector.TYPE_HORIZONTAL_FRAME) : null
+            onPopupContentHeightChanged: updateContentHeight(popupContentHeight)
+        }
+
+        ArticulationSettings {
+            popupPositionX: mapToGlobal(grid.x, grid.y).x - mapToGlobal(x, y).x
+            popupAvailableWidth: root.width
+            model: root.model ? root.model.modelByType(Inspector.TYPE_ARTICULATION) : null
+            onPopupContentHeightChanged: updateContentHeight(popupContentHeight)
+        }
+
+        OrnamentSettings {
+            popupPositionX: mapToGlobal(grid.x, grid.y).x - mapToGlobal(x, y).x
+            popupAvailableWidth: root.width
+            model: root.model ? root.model.modelByType(Inspector.TYPE_ORNAMENT) : null
             onPopupContentHeightChanged: updateContentHeight(popupContentHeight)
         }
     }

--- a/inspectors/view/qml/notation/articulations/ArticulationPopup.qml
+++ b/inspectors/view/qml/notation/articulations/ArticulationPopup.qml
@@ -1,0 +1,95 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import MuseScore.Inspectors 3.3
+import "../../common"
+
+StyledPopup {
+    id: root
+
+    property QtObject model: null
+
+    implicitHeight: contentColumn.implicitHeight + topPadding + bottomPadding
+    width: parent.width
+
+    Column {
+        id: contentColumn
+
+        width: parent.width
+
+        spacing: 12
+
+        StyledTextLabel {
+            text: qsTr("Direction")
+        }
+
+        RadioButtonGroup {
+            id: radioButtonList
+
+            height: 30
+            width: parent.width
+
+            model: [
+                { iconRole: IconNameTypes.AUTO, typeRole: Articulation.AUTO },
+                { iconRole: IconNameTypes.ARROW_DOWN, typeRole: Articulation.DOWN },
+                { iconRole: IconNameTypes.ARROW_UP, typeRole: Articulation.UP }
+            ]
+
+            delegate: FlatRadioButton {
+
+                ButtonGroup.group: radioButtonList.radioButtonGroup
+
+                checked: root.model && !root.model.direction.isUndefined ? root.model.direction.value === modelData["typeRole"]
+                                                                                     : false
+
+                onToggled: {
+                    root.model.direction.value = modelData["typeRole"]
+                }
+
+                StyledIconLabel {
+                    iconCode: modelData["iconRole"]
+                }
+            }
+        }
+
+        Column {
+            spacing: 8
+
+            width: parent.width
+
+            StyledTextLabel {
+                text: qsTr("Placement")
+            }
+
+            StyledComboBox {
+                width: parent.width
+
+                textRoleName: "text"
+                valueRoleName: "value"
+
+                model: [
+                    { text: qsTr("Above staff"), value: ArticulationTypes.TYPE_ABOVE_STAFF },
+                    { text: qsTr("Below staff"), value: ArticulationTypes.TYPE_BELOW_STAFF },
+                    { text: qsTr("Chord automatic"), value: ArticulationTypes.TYPE_CHORD_AUTO },
+                    { text: qsTr("Above chord"), value: ArticulationTypes.TYPE_ABOVE_CHORD },
+                    { text: qsTr("Below chord"), value: ArticulationTypes.TYPE_BELOW_CHORD }
+                ]
+
+                currentIndex: root.model && !root.model.placement.isUndefined ? indexOfValue(root.model.placement.value) : -1
+
+                onValueChanged: {
+                    root.model.placement.value = value
+                }
+            }
+        }
+
+        FlatButton {
+            id: propertiesButton
+
+            width: parent.width
+            text: qsTr("Channel & Midi properties")
+
+            onClicked: {
+            }
+        }
+    }
+}

--- a/inspectors/view/qml/notation/articulations/ArticulationPopup.qml
+++ b/inspectors/view/qml/notation/articulations/ArticulationPopup.qml
@@ -83,12 +83,12 @@ StyledPopup {
         }
 
         FlatButton {
-            id: propertiesButton
-
-            width: parent.width
             text: qsTr("Channel & Midi properties")
 
             onClicked: {
+                if (root.model) {
+                    root.model.openChannelAndMidiProperties()
+                }
             }
         }
     }

--- a/inspectors/view/qml/notation/articulations/ArticulationPopup.qml
+++ b/inspectors/view/qml/notation/articulations/ArticulationPopup.qml
@@ -29,9 +29,9 @@ StyledPopup {
             width: parent.width
 
             model: [
-                { iconRole: IconNameTypes.AUTO, typeRole: Articulation.AUTO },
-                { iconRole: IconNameTypes.ARROW_DOWN, typeRole: Articulation.DOWN },
-                { iconRole: IconNameTypes.ARROW_UP, typeRole: Articulation.UP }
+                { iconRole: IconNameTypes.AUTO, typeRole: ArticulationTypes.AUTO },
+                { iconRole: IconNameTypes.ARROW_DOWN, typeRole: ArticulationTypes.DOWN },
+                { iconRole: IconNameTypes.ARROW_UP, typeRole: ArticulationTypes.UP }
             ]
 
             delegate: FlatRadioButton {
@@ -86,9 +86,7 @@ StyledPopup {
             text: qsTr("Channel & Midi properties")
 
             onClicked: {
-                if (root.model) {
-                    root.model.openChannelAndMidiProperties()
-                }
+                root.model.openChannelAndMidiProperties()
             }
         }
     }

--- a/inspectors/view/qml/notation/articulations/ArticulationSettings.qml
+++ b/inspectors/view/qml/notation/articulations/ArticulationSettings.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.9
+import QtQuick.Layouts 1.3
+import MuseScore.Inspectors 3.3
+import "../../common"
+
+PopupViewButton {
+    id: root
+
+    property alias model: articulationPopup.model
+
+    icon: IconNameTypes.ARTICULATION
+    text: qsTr("Articulation")
+
+    visible: root.model ? !root.model.isEmpty : false
+
+    ArticulationPopup {
+        id: articulationPopup
+
+        x: popupPositionX
+        y: popupPositionY
+        arrowX: parent.x + parent.width / 2
+        width: popupAvailableWidth
+    }
+}

--- a/inspectors/view/qml/notation/notes/BeamSettings.qml
+++ b/inspectors/view/qml/notation/notes/BeamSettings.qml
@@ -58,8 +58,6 @@ FocusableItem {
                                              : false
 
                 StyledTextLabel {
-                    id: stedDirectionLabel
-
                     text: qsTr("Feathered beams")
                 }
 

--- a/inspectors/view/qml/notation/notes/StemSettings.qml
+++ b/inspectors/view/qml/notation/notes/StemSettings.qml
@@ -37,8 +37,6 @@ FocusableItem {
         }
 
         StyledTextLabel {
-            id: stedDirectionLabel
-
             text: qsTr("Stem direction")
         }
 

--- a/inspectors/view/qml/notation/ornaments/OrnamentPopup.qml
+++ b/inspectors/view/qml/notation/ornaments/OrnamentPopup.qml
@@ -86,12 +86,12 @@ StyledPopup {
         }
 
         FlatButton {
-            id: propertiesButton
-
-            width: parent.width
             text: qsTr("Channel & Midi properties")
 
             onClicked: {
+                if (root.model) {
+                    root.model.openChannelAndMidiProperties()
+                }
             }
         }
     }

--- a/inspectors/view/qml/notation/ornaments/OrnamentPopup.qml
+++ b/inspectors/view/qml/notation/ornaments/OrnamentPopup.qml
@@ -1,0 +1,98 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import MuseScore.Inspectors 3.3
+import "../../common"
+
+StyledPopup {
+    id: root
+
+    property QtObject model: null
+
+    implicitHeight: contentColumn.implicitHeight + topPadding + bottomPadding
+    width: parent.width
+
+    Column {
+        id: contentColumn
+
+        width: parent.width
+
+        spacing: 12
+
+        StyledTextLabel {
+            text: qsTr("Performance")
+        }
+
+        RadioButtonGroup {
+            id: radioButtonList
+
+            height: 30
+            width: parent.width
+
+            model: [
+                { textRole: qsTr("Standard"), valueRole: Ornament.STYLE_STANDART },
+                { textRole: qsTr("Baroque"), valueRole: Ornament.STYLE_BAROQUE }
+            ]
+
+            delegate: FlatRadioButton {
+                id: radioButtonDelegate
+
+                ButtonGroup.group: radioButtonList.radioButtonGroup
+
+                checked: root.model && !root.model.performanceType.isUndefined ? root.model.performanceType.value === modelData["valueRole"]
+                                                                        : false
+                onToggled: {
+                    root.model.performanceType.value = modelData["valueRole"]
+                }
+
+                StyledTextLabel {
+                    text: modelData["textRole"]
+
+                    elide: Text.ElideRight
+                    verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+        }
+
+        Column {
+            spacing: 8
+
+            width: parent.width
+
+            StyledTextLabel {
+                text: qsTr("Placement")
+            }
+
+            StyledComboBox {
+                width: parent.width
+
+                textRoleName: "text"
+                valueRoleName: "value"
+
+                model: [
+                    { text: qsTr("Above staff"), value: ArticulationTypes.TYPE_ABOVE_STAFF },
+                    { text: qsTr("Below staff"), value: ArticulationTypes.TYPE_BELOW_STAFF },
+                    { text: qsTr("Chord automatic"), value: ArticulationTypes.TYPE_CHORD_AUTO },
+                    { text: qsTr("Above chord"), value: ArticulationTypes.TYPE_ABOVE_CHORD },
+                    { text: qsTr("Below chord"), value: ArticulationTypes.TYPE_BELOW_CHORD }
+                ]
+
+                currentIndex: root.model && !root.model.placement.isUndefined ? indexOfValue(root.model.placement.value) : -1
+
+                onValueChanged: {
+                    root.model.placement.value = value
+                }
+            }
+        }
+
+        FlatButton {
+            id: propertiesButton
+
+            width: parent.width
+            text: qsTr("Channel & Midi properties")
+
+            onClicked: {
+            }
+        }
+    }
+}

--- a/inspectors/view/qml/notation/ornaments/OrnamentPopup.qml
+++ b/inspectors/view/qml/notation/ornaments/OrnamentPopup.qml
@@ -29,8 +29,8 @@ StyledPopup {
             width: parent.width
 
             model: [
-                { textRole: qsTr("Standard"), valueRole: Ornament.STYLE_STANDART },
-                { textRole: qsTr("Baroque"), valueRole: Ornament.STYLE_BAROQUE }
+                { textRole: qsTr("Standard"), valueRole: OrnamentTypes.STYLE_STANDARD },
+                { textRole: qsTr("Baroque"), valueRole: OrnamentTypes.STYLE_BAROQUE }
             ]
 
             delegate: FlatRadioButton {

--- a/inspectors/view/qml/notation/ornaments/OrnamentSettings.qml
+++ b/inspectors/view/qml/notation/ornaments/OrnamentSettings.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.9
+import QtQuick.Layouts 1.3
+import MuseScore.Inspectors 3.3
+import "../../common"
+
+PopupViewButton {
+    id: root
+
+    property alias model: ornamentPopup.model
+
+    icon: IconNameTypes.ORNAMENT
+    text: qsTr("Ornament")
+
+    visible: root.model ? !root.model.isEmpty : false
+
+    OrnamentPopup {
+        id: ornamentPopup
+
+        x: popupPositionX
+        y: popupPositionY
+        arrowX: parent.x + parent.width / 2
+        width: popupAvailableWidth
+    }
+}

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6546,6 +6546,9 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       else if (cmd == "show-staff-text-properties") {
             showPropertiesDialogByElementType(Ms::ElementType::STAFF_TEXT);
             }
+      else if (cmd == "show-articulation-properties") {
+            showPropertiesDialogByElementType(Ms::ElementType::ARTICULATION);
+            }
       else if (cmd == "show-corrupted-measures") {
             MScore::showCorruptedMeasures = a->isChecked();
             if (cs) {

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2438,8 +2438,17 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "show-staff-text-properties",
-         QT_TRANSLATE_NOOP("action","Show staff text properties"),
-         QT_TRANSLATE_NOOP("action","Show staff text properties"),
+         QT_TRANSLATE_NOOP("action","Staff text properties..."),
+         QT_TRANSLATE_NOOP("action","Edit staff text properties"),
+         0,
+         Icons::Invalid_ICON
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "show-articulation-properties",
+         QT_TRANSLATE_NOOP("action","Articulation properties..."),
+         QT_TRANSLATE_NOOP("action","Edit articulation properties"),
          0,
          Icons::Invalid_ICON
          },


### PR DESCRIPTION
- Fixed incorrect naming of the stemtypes.h file (ex- direction.h)
- Fixed incorrect naming of the ornnamenttypes.h file (ex- articulationtypes.h)
- Implemented view for the articulation popup
- Fixed few warnings (reg. not used [this] in lambdas)
- Removed redundant ids from Beam* and StemSettings.qml

TODO:
- The changes made in Channel & Midi Properties don't apply to the score elements, but are applied to the inspector properties