### PR TITLE
Fix compilation errors for MSVC

### DIFF
--- a/inspectors/models/abstractinspectormodel.cpp
+++ b/inspectors/models/abstractinspectormodel.cpp
@@ -84,7 +84,7 @@ QList<Ms::ElementType> AbstractInspectorModel::supportedElementTypesBySectionTyp
     switch (sectionType) {
     case SECTION_GENERAL:
         return { Ms::ElementType::MAXTYPE };
-    case SECTION_NOTATION:
+    case SECTION_NOTATION: {
         static QList<Ms::ElementType> notationTypes = { Ms::ElementType::NOTE,
                                                         Ms::ElementType::STEM,
                                                         Ms::ElementType::NOTEDOT,
@@ -109,13 +109,13 @@ QList<Ms::ElementType> AbstractInspectorModel::supportedElementTypesBySectionTyp
                                                         Ms::ElementType::HAIRPIN,
                                                         Ms::ElementType::HAIRPIN_SEGMENT };
         return notationTypes;
-
-    case SECTION_TEXT:
+    }
+    case SECTION_TEXT: {
         static QList<Ms::ElementType> textTypes = { Ms::ElementType::TEXT, Ms::ElementType::TEXTLINE,
                                                     Ms::ElementType::TEXTLINE_BASE, Ms::ElementType::TEXTLINE_SEGMENT,
                                                     Ms::ElementType::STAFF_TEXT, Ms::ElementType::SYSTEM_TEXT};
         return textTypes;
-
+    }
     default:
         return QList<Ms::ElementType>();
     }

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1782,15 +1782,15 @@ void TextBase::genText() const
 //   selectAll
 //---------------------------------------------------------
 
-void TextBase::selectAll(TextCursor* _cursor)
+void TextBase::selectAll(TextCursor* cursor)
       {
       if (_layout.isEmpty())
           return;
 
-      _cursor->setSelectLine(0);
-      _cursor->setSelectColumn(0);
-      _cursor->setRow(rows() - 1);
-      _cursor->setColumn(_cursor->curLine().columns());
+      cursor->setSelectLine(0);
+      cursor->setSelectColumn(0);
+      cursor->setRow(rows() - 1);
+      cursor->setColumn(cursor->curLine().columns());
       }
 
 //---------------------------------------------------------
@@ -1969,8 +1969,8 @@ QRectF TextBase::pageRectangle() const
 void TextBase::dragTo(EditData& ed)
       {
       TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
-      TextCursor* _cursor = ted->cursor();
-      _cursor->set(ed.pos, QTextCursor::KeepAnchor);
+      TextCursor* cursor = ted->cursor();
+      cursor->set(ed.pos, QTextCursor::KeepAnchor);
       score()->setUpdateAll();
       score()->update();
       }

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -852,7 +852,7 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
 #ifdef Q_OS_WIN // Japenese IME on Windows needs to know when Ctrl/Alt/Shift/CapsLock is pressed while in predit
       if (textEdit) {
             TextBase* text = toTextBase(editData.element);
-            if (text->cursor(editData)->format()->preedit() && QGuiApplication::inputMethod()->locale().script() == QLocale::JapaneseScript &&
+            if (text->cursorFromEditData(editData)->format()->preedit() && QGuiApplication::inputMethod()->locale().script() == QLocale::JapaneseScript &&
                 ((editData.key == Qt::Key_Control || (editData.modifiers & Qt::ControlModifier)) ||
                  (editData.key == Qt::Key_Alt     || (editData.modifiers & Qt::AltModifier)) ||
                  (editData.key == Qt::Key_Shift   || (editData.modifiers & Qt::ShiftModifier)) ||


### PR DESCRIPTION
Errors fixed:

- textbase.cpp: _cursor parameter hides member of TextBase class.

- abstractinspectormodel.cpp: Variables not instantiated for some cases in
  switch statement.

- events.cpp: Cursor function takes no arguments.