### PR TITLE
Fix formatting for the T/V/H frames controls

### DIFF
--- a/inspectors/models/notation/frames/horizontalframesettingsmodel.cpp
+++ b/inspectors/models/notation/frames/horizontalframesettingsmodel.cpp
@@ -23,12 +23,13 @@ void HorizontalFrameSettingsModel::requestElements()
 
 void HorizontalFrameSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_frameWidth, [] (const QVariant& elementPropertyValue) -> QVariant {
+    auto formatter = [] (const QVariant& elementPropertyValue) -> QVariant {
         return QString::number(elementPropertyValue.toDouble(), 'f', 2).toDouble();
-    });
+    };
 
-    loadPropertyItem(m_leftGap);
-    loadPropertyItem(m_rightGap);
+    loadPropertyItem(m_frameWidth, formatter);
+    loadPropertyItem(m_leftGap, formatter);
+    loadPropertyItem(m_rightGap, formatter);
     loadPropertyItem(m_shouldDisplayKeysAndBrackets);
 }
 

--- a/inspectors/models/notation/frames/textframesettingsmodel.cpp
+++ b/inspectors/models/notation/frames/textframesettingsmodel.cpp
@@ -25,12 +25,16 @@ void TextFrameSettingsModel::requestElements()
 
 void TextFrameSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_gapAbove);
-    loadPropertyItem(m_gapBelow);
-    loadPropertyItem(m_frameLeftMargin);
-    loadPropertyItem(m_frameRightMargin);
-    loadPropertyItem(m_frameTopMargin);
-    loadPropertyItem(m_frameBottomMargin);
+    auto formatter = [] (const QVariant& elementPropertyValue) -> QVariant {
+        return QString::number(elementPropertyValue.toDouble(), 'f', 2).toDouble();
+    };
+
+    loadPropertyItem(m_gapAbove, formatter);
+    loadPropertyItem(m_gapBelow, formatter);
+    loadPropertyItem(m_frameLeftMargin, formatter);
+    loadPropertyItem(m_frameRightMargin, formatter);
+    loadPropertyItem(m_frameTopMargin, formatter);
+    loadPropertyItem(m_frameBottomMargin, formatter);
 }
 
 void TextFrameSettingsModel::resetProperties()

--- a/inspectors/models/notation/frames/verticalframesettingsmodel.cpp
+++ b/inspectors/models/notation/frames/verticalframesettingsmodel.cpp
@@ -26,16 +26,17 @@ void VerticalFrameSettingsModel::requestElements()
 
 void VerticalFrameSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_frameHeight, [] (const QVariant& elementPropertyValue) -> QVariant {
+    auto formatter = [] (const QVariant& elementPropertyValue) -> QVariant {
         return QString::number(elementPropertyValue.toDouble(), 'f', 2).toDouble();
-    });
+    };
 
-    loadPropertyItem(m_gapAbove);
-    loadPropertyItem(m_gapBelow);
-    loadPropertyItem(m_frameLeftMargin);
-    loadPropertyItem(m_frameRightMargin);
-    loadPropertyItem(m_frameTopMargin);
-    loadPropertyItem(m_frameBottomMargin);
+    loadPropertyItem(m_frameHeight, formatter);
+    loadPropertyItem(m_gapAbove, formatter);
+    loadPropertyItem(m_gapBelow, formatter);
+    loadPropertyItem(m_frameLeftMargin, formatter);
+    loadPropertyItem(m_frameRightMargin, formatter);
+    loadPropertyItem(m_frameTopMargin, formatter);
+    loadPropertyItem(m_frameBottomMargin, formatter);
 }
 
 void VerticalFrameSettingsModel::resetProperties()


### PR DESCRIPTION
To avoid numbers in the controls like 7.000000000000 -> will be 7.00 instead.