### PR TITLE
Update API functions

### DIFF
--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -63,7 +63,7 @@ typedef struct ms_DynamicsEvent
 {
   long _location_ms;
   double _value; // 0.0 - 1.0
-} ms_DyamicsEvent;
+} ms_DynamicsEvent;
 
 enum ms_NoteArticulation : uint64_t
 {
@@ -107,27 +107,10 @@ enum ms_NoteArticulation : uint64_t
     ms_NoteArticulation_Diamond = 1LL << 36,
     ms_NoteArticulation_Portamento = 1LL << 37,
     ms_NoteArticulation_Pizzicato = 1LL << 38,
-};
-
-enum ms_TwoNoteArticulation : uint64_t
-{
-    ms_TwoNoteArticulation_None = 0,
-    ms_TwoNoteArticulation_TwoNoteTremolo = 1LL << 1,
-    ms_TwoNoteArticulation_Glissando = 1LL << 2,
-    ms_TwoNoteArticulation_Portamento = 1LL << 3,
-};
-
-enum ms_RangeArticulation : uint64_t
-{
-    ms_RangeArticulation_None = 0,
-    ms_RangeArticulation_Slur = 1LL << 1,
-    ms_RangeArticulation_Pedal = 1LL << 2,
-};
-
-enum ms_EventType
-{
-    ms_EventTypeNote = 0,
-    ms_EventTypeSlur = 1
+    ms_NoteArticulation_TwoNoteTremolo = 1LL << 39,
+    ms_NoteArticulation_Glissando = 1LL << 40,
+    ms_NoteArticulation_Pedal = 1LL << 41,
+    ms_NoteArticulation_Slur = 1LL << 42,
 };
 
 typedef struct ms_NoteEvent
@@ -140,34 +123,6 @@ typedef struct ms_NoteEvent
     ms_NoteArticulation _articulation;
 } ms_NoteEvent;
 
-typedef struct ms_TwoNoteArticulationEvent
-{
-    int _voice; // 0-3
-    long _second_note_location_ms;
-    ms_TwoNoteArticulation _articulation;
-} ms_TwoNoteArticulationEvent;
-
-typedef struct ms_RangeArticulationEvent
-{
-    int _voice; // 0-3
-    long _start_location_ms;
-    long _end_location_ms;
-    ms_RangeArticulation _articulation;
-} ms_RangeArticulationEvent;
-
-typedef struct ms_Event
-{
-    ms_EventType _event_type;
-    union
-    {
-        ms_NoteEvent _note;
-        // Notes must both already exist in the given voice
-        ms_TwoNoteArticulationEvent _two_note_articulation;
-        // Range of notes must already exist, and notes must exist starting at
-        // start and ending at end of marked range.
-        ms_RangeArticulationEvent _range_articulation;
-    } _event;
-} ms_Event;
 
 typedef ms_Result (* ms_init)();
 typedef ms_InstrumentList (* ms_get_instrument_list)();
@@ -192,15 +147,15 @@ typedef ms_Track (* ms_MuseSampler_add_track)(ms_MuseSampler ms, int instrument_
 typedef ms_Result (* ms_MuseSampler_finalize_track)(ms_MuseSampler ms, ms_Track track);
 typedef ms_Result (* ms_MuseSampler_clear_track)(ms_MuseSampler ms, ms_Track track);
 
+typedef ms_Result (* ms_MuseSampler_add_track_note_event)(ms_MuseSampler ms, ms_Track track, ms_NoteEvent evt);
 typedef ms_Result (* ms_MuseSampler_add_track_dynamics_event)(ms_MuseSampler ms, ms_Track track, ms_DynamicsEvent evt);
-typedef ms_Result (* ms_MuseSampler_add_track_event)(ms_MuseSampler ms, ms_Track track, ms_Event evt);
 
-typedef bool (* ms_MuseSampler_is_ranged_articulation)(ms_MuseSampler ms, ms_NoteArticulation);
+typedef int (* ms_MuseSampler_is_ranged_articulation)(ms_MuseSampler ms, ms_NoteArticulation);
 typedef ms_Result (* ms_MuseSampler_add_track_event_range_start)(ms_MuseSampler ms, ms_Track);
 typedef ms_Result (* ms_MuseSampler_add_track_event_range_end)(ms_MuseSampler ms, ms_Track);
 
 typedef ms_Result (* ms_MuseSampler_process)(ms_MuseSampler, ms_OutputBuffer, long long micros);
 typedef void (*ms_MuseSampler_set_position)(ms_MuseSampler, long long micros);
-typedef void (*ms_MuseSampler_set_playing)(ms_MuseSampler, bool playing);
+typedef void (*ms_MuseSampler_set_playing)(ms_MuseSampler, int playing);
 
 #endif // MU_MUSESAMPLER_APITYPES_H

--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -60,14 +60,14 @@ struct MuseSamplerLibHandler
     ms_Result clearTrack(ms_MuseSampler ms, ms_Track track) { return ms_MuseSampler_clear_track(ms, track); }
 
     ms_Result addDynamicsEvent(ms_MuseSampler ms, ms_Track track, ms_DynamicsEvent evt) { return ms_MuseSampler_add_track_dynamics_event(ms, track, evt); }
-    ms_Result addTrackEvent(ms_MuseSampler ms, ms_Track track, ms_Event evt) { return ms_MuseSampler_add_track_event(ms, track, evt); }
+    ms_Result addNoteEvent(ms_MuseSampler ms, ms_Track track, ms_Event evt) { return ms_MuseSampler_add_track_note_event(ms, track, evt); }
 
-    bool isRangedArticulation(ms_MuseSampler ms, ms_NoteArticulation art) { return ms_MuseSampler_is_ranged_articulation(ms, art); }
+    bool isRangedArticulation(ms_MuseSampler ms, ms_NoteArticulation art) { return ms_MuseSampler_is_ranged_articulation(ms, art) == 1; }
     ms_Result addTrackEventRangeStart(ms_MuseSampler ms, ms_Track track) { return ms_MuseSampler_add_track_event_range_start(ms, track); }
     ms_Result addTrackEventRangeEnd(ms_MuseSampler ms, ms_Track track) { return ms_MuseSampler_add_track_event_range_end(ms, track); }
 
     void setPosition(ms_MuseSampler ms, long long micros) { return ms_MuseSampler_set_position(ms, micros); }
-    void setPlaying(ms_MuseSampler ms, bool playing) { return ms_MuseSampler_set_playing(ms, playing); }
+    void setPlaying(ms_MuseSampler ms, bool playing) { return ms_MuseSampler_set_playing(ms, playing ? 1 : 0); }
     ms_Result process(ms_MuseSampler ms, ms_OutputBuffer buff, long long micros) { return ms_MuseSampler_process(ms, buff, micros); }
 
     bool containsInstrument(const char* musicXmlSoundId)
@@ -121,7 +121,7 @@ struct MuseSamplerLibHandler
     ms_MuseSampler_clear_track clearTrack = nullptr;
 
     ms_MuseSampler_add_track_dynamics_event addDynamicsEvent = nullptr;
-    ms_MuseSampler_add_track_event addTrackEvent = nullptr;
+    ms_MuseSampler_add_track_note_event addNoteEvent = nullptr;
     ms_MuseSampler_is_ranged_articulation isRangedArticulation = nullptr;
     ms_MuseSampler_add_track_event_range_start addTrackEventRangeStart = nullptr;
     ms_MuseSampler_add_track_event_range_end addTrackEventRangeEnd = nullptr;
@@ -193,7 +193,7 @@ struct MuseSamplerLibHandler
         clearTrack = (ms_MuseSampler_clear_track)dlsym(m_lib, "ms_MuseSampler_clear_track");
 
         addDynamicsEvent = (ms_MuseSampler_add_track_dynamics_event)dlsym(m_lib, "ms_MuseSampler_add_track_dynamics_event");
-        addTrackEvent = (ms_MuseSampler_add_track_event)dlsym(m_lib, "ms_MuseSampler_add_track_event");
+        addNoteEvent = (ms_MuseSampler_add_track_note_event)dlsym(m_lib, "ms_MuseSampler_add_track_note_event");
 
         isRangedArticulation = (ms_MuseSampler_is_ranged_articulation)dlsym(m_lib, "ms_MuseSampler_is_ranged_articulation");
         addTrackEventRangeStart = (ms_MuseSampler_add_track_event_range_start)dlsym(m_lib, "ms_MuseSampler_add_track_event_range_start");
@@ -235,12 +235,12 @@ struct MuseSamplerLibHandler
                && finalizeTrack
                && clearTrack
                && addDynamicsEvent
-               && addTrackEvent
+               && addNoteEvent
                && setPosition
                && setPlaying
-               //&& isRangedArticulation
-               //&& addTrackEventRangeStart
-               //&& addTrackEventRangeEnd
+               && isRangedArticulation
+               && addTrackEventRangeStart
+               && addTrackEventRangeEnd
                && process;
     }
 
@@ -263,7 +263,7 @@ private:
                << "\n ms_MuseSampler_add_track - " << reinterpret_cast<uint64_t>(addTrack)
                << "\n ms_MuseSampler_finalize_track - " << reinterpret_cast<uint64_t>(finalizeTrack)
                << "\n ms_MuseSampler_add_track_dynamics_event - " << reinterpret_cast<uint64_t>(addDynamicsEvent)
-               << "\n ms_MuseSampler_add_track_event - " << reinterpret_cast<uint64_t>(addTrackEvent)
+               << "\n ms_MuseSampler_add_track_note_event - " << reinterpret_cast<uint64_t>(addNoteEvent)
                << "\n ms_MuseSampler_set_position - " << reinterpret_cast<uint64_t>(setPosition)
                << "\n ms_MuseSampler_set_playing - " << reinterpret_cast<uint64_t>(setPlaying)
                << "\n ms_MuseSampler_process - " << reinterpret_cast<uint64_t>(process);

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -345,22 +345,21 @@ void MuseSamplerWrapper::addNoteEvent(const mpe::NoteEvent& noteEvent)
         return;
     }
 
-    ms_Event event;
-    event._event_type = ms_EventTypeNote;
-    event._event._note = ms_NoteEvent();
-    event._event._note._voice = noteEvent.arrangementCtx().voiceLayerIndex;
-    event._event._note._location_ms = noteEvent.arrangementCtx().nominalTimestamp;
-    event._event._note._duration_ms = noteEvent.arrangementCtx().nominalDuration;
-    event._event._note._pitch = pitchIndex(noteEvent.pitchCtx().nominalPitchLevel);
-    event._event._note._tempo = 0.0;
-    event._event._note._articulation = noteArticulationTypes(noteEvent);
+    ms_NoteEvent event{};
+    event._voice = noteEvent.arrangementCtx().voiceLayerIndex;
+    event._location_ms = noteEvent.arrangementCtx().nominalTimestamp;
+    event._duration_ms = noteEvent.arrangementCtx().nominalDuration;
+    event._pitch = pitchIndex(noteEvent.pitchCtx().nominalPitchLevel);
+    event._tempo = 0.0;
+    event._articulation = noteArticulationTypes(noteEvent);
 
-    if (m_samplerLib->addTrackEvent(m_sampler, m_track, event) != ms_Result_OK) {
+    if (m_samplerLib->addNoteEvent(m_sampler, m_track, event) != ms_Result_OK) {
         LOGE() << "Unable to add event for track";
     } else {
-        LOGI() << "Successfully added note event, pitch: " << event._event._note._pitch
-               << ", timestamp: " << noteEvent.arrangementCtx().nominalTimestamp
-               << ", articulations flag: " << event._event._note._articulation;
+        LOGI() << "Successfully added note event, pitch: " << event._pitch
+               << ", timestamp: " << event._location_ms
+               << ", duration: " << event._duration_ms
+               << ", articulations flag: " << event._articulation;
     }
 }
 


### PR DESCRIPTION
- Use "note event" instead of old "event" union type.
- Actually require is ranged and start/end ranged functions.