### PR TITLE
Remove two note tremolo from API

### DIFF
--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -106,7 +106,6 @@ enum ms_NoteArticulation : uint64_t
     ms_NoteArticulation_Diamond = 1LL << 35,
     ms_NoteArticulation_Portamento = 1LL << 36,
     ms_NoteArticulation_Pizzicato = 1LL << 37,
-    ms_NoteArticulation_TwoNoteTremolo = 1LL << 38,
     ms_NoteArticulation_Glissando = 1LL << 39,
     ms_NoteArticulation_Pedal = 1LL << 40,
     ms_NoteArticulation_Slur = 1LL << 41,


### PR DESCRIPTION
two note trems aren't really represented in MuseScore mpe events; instead, these are sent as "tremolo" events and deduced from fallback articulations.  This removes the values from the API.

(ideally, we'd just shift all the other articulations down too, but we can do a larger enum cleanup with changes later if we decide to break compatibility during the testing cycle)