### PR TITLE
Compatible resources check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ set(VST3_SDK_VERSION "3.7")
 option(BUILD_VST "Build VST MODULE" OFF)
 set(VST3_SDK_PATH "" CACHE PATH "Path to VST3_SDK. SDK version >= ${VST3_SDK_VERSION} required")
 
-option(BUILD_MUSESAMPLER_MODULE "Build MuseSampler MODULE" OFF)
+option(BUILD_MUSESAMPLER_MODULE "Build MuseSampler MODULE" ON)
 set(MUSESAMPLER_SRC_PATH "" CACHE PATH "Path to MuseSampler sources")
 
 option(ENABLE_AUDIO_EXPORT "Enable audio export" ON)

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -151,7 +151,8 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol, const
                                            voiceIdx,
                                            pitchLevel,
                                            dynamicLevelFromType(mpe::DynamicType::Natural),
-                                           emptyArticulations));
+                                           emptyArticulations,
+                                           2.0));
     }
 }
 

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -126,7 +126,8 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol,
                                            voiceIdx,
                                            pitchLevel,
                                            dynamicLevelFromType(mpe::DynamicType::Natural),
-                                           emptyArticulations));
+                                           emptyArticulations,
+                                           bps.val));
     }
 }
 
@@ -185,7 +186,8 @@ void PlaybackEventsRenderer::renderMetronome(const Score* score, const int measu
                                                            0,
                                                            eventPitchLevel,
                                                            dynamicLevelFromType(mpe::DynamicType::Natural),
-                                                           emptyArticulations));
+                                                           emptyArticulations,
+                                                           bps.val));
     }
 }
 

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -194,7 +194,7 @@ void PlaybackModel::triggerEventsForItems(const std::vector<const EngravingItem*
 
     constexpr timestamp_t actualTimestamp = 0;
     constexpr dynamic_level_t actualDynamicLevel = dynamicLevelFromType(mpe::DynamicType::Natural);
-    duration_t actualDuration = MScore::defaultPlayDuration;
+    duration_t actualDuration = MScore::defaultPlayDuration * 1000;
 
     for (const EngravingItem* item : playableItems) {
         if (item->isHarmony()) {

--- a/src/engraving/playback/renderingcontext.h
+++ b/src/engraving/playback/renderingcontext.h
@@ -117,6 +117,7 @@ struct NominalNoteCtx {
     voice_idx_t voiceIdx = 0;
     mpe::timestamp_t timestamp = 0;
     mpe::duration_t duration = 0;
+    BeatsPerSecond tempo = 0;
 
     mpe::pitch_level_t pitchLevel = 0;
 
@@ -126,6 +127,7 @@ struct NominalNoteCtx {
         : voiceIdx(note->voice()),
         timestamp(ctx.nominalTimestamp),
         duration(noteNominalDuration(note, ctx)),
+        tempo(ctx.beatsPerSecond),
         pitchLevel(notePitchLevel(note->playingTpc(), note->playingOctave())),
         chordCtx(ctx)
     {}
@@ -138,7 +140,8 @@ inline mpe::NoteEvent buildNoteEvent(NominalNoteCtx&& ctx)
                           static_cast<mpe::voice_layer_idx_t>(ctx.voiceIdx),
                           ctx.pitchLevel,
                           ctx.chordCtx.nominalDynamicLevel,
-                          ctx.chordCtx.commonArticulations);
+                          ctx.chordCtx.commonArticulations,
+                          ctx.tempo.val);
 }
 
 inline mpe::NoteEvent buildNoteEvent(const Note* note, const RenderingContext& ctx)
@@ -148,7 +151,8 @@ inline mpe::NoteEvent buildNoteEvent(const Note* note, const RenderingContext& c
                           static_cast<mpe::voice_layer_idx_t>(note->voice()),
                           notePitchLevel(note->playingTpc(), note->playingOctave()),
                           ctx.nominalDynamicLevel,
-                          ctx.commonArticulations);
+                          ctx.commonArticulations,
+                          ctx.beatsPerSecond.val);
 }
 
 inline mpe::NoteEvent buildNoteEvent(NominalNoteCtx&& ctx, const mpe::duration_t eventDuration,
@@ -160,7 +164,8 @@ inline mpe::NoteEvent buildNoteEvent(NominalNoteCtx&& ctx, const mpe::duration_t
                           static_cast<mpe::voice_layer_idx_t>(ctx.voiceIdx),
                           ctx.pitchLevel + pitchLevelOffset,
                           ctx.chordCtx.nominalDynamicLevel,
-                          ctx.chordCtx.commonArticulations);
+                          ctx.chordCtx.commonArticulations,
+                          ctx.tempo.val);
 }
 
 inline mpe::NoteEvent buildFixedNoteEvent(const Note* note, const mpe::timestamp_t actualTimestamp,
@@ -172,7 +177,8 @@ inline mpe::NoteEvent buildFixedNoteEvent(const Note* note, const mpe::timestamp
                           static_cast<mpe::voice_layer_idx_t>(note->voice()),
                           notePitchLevel(note->playingTpc(), note->playingOctave()),
                           actualDynamicLevel,
-                          articulations);
+                          articulations,
+                          1); // TBD: add tempo!
 }
 }
 

--- a/src/framework/audio/abstractsynthesizer.cpp
+++ b/src/framework/audio/abstractsynthesizer.cpp
@@ -23,6 +23,7 @@
 #include "abstractsynthesizer.h"
 
 #include "internal/audiosanitizer.h"
+#include "internal/worker/audioengine.h"
 
 using namespace mu;
 using namespace mu::mpe;
@@ -33,6 +34,10 @@ AbstractSynthesizer::AbstractSynthesizer(const AudioInputParams& params)
     : m_params(params)
 {
     ONLY_AUDIO_WORKER_THREAD;
+
+    AudioEngine::instance()->modeChanged().onNotify(this, [this]() {
+        updateRenderingMode(AudioEngine::instance()->mode());
+    });
 }
 
 const AudioInputParams& AbstractSynthesizer::params() const
@@ -60,6 +65,11 @@ void AbstractSynthesizer::setup(const mpe::PlaybackData& playbackData)
 }
 
 void AbstractSynthesizer::revokePlayingNotes()
+{
+    ONLY_AUDIO_WORKER_THREAD;
+}
+
+void AbstractSynthesizer::updateRenderingMode(const RenderMode /*mode*/)
 {
     ONLY_AUDIO_WORKER_THREAD;
 }

--- a/src/framework/audio/abstractsynthesizer.h
+++ b/src/framework/audio/abstractsynthesizer.h
@@ -59,6 +59,7 @@ protected:
 
     virtual void setupSound(const mpe::PlaybackSetupData& setupData) = 0;
     virtual void setupEvents(const mpe::PlaybackData& playbackData) = 0;
+    virtual void updateRenderingMode(const RenderMode mode);
 
     msecs_t samplesToMsecs(const samples_t samplesPerChannel, const samples_t sampleRate) const;
     samples_t microSecsToSamples(const msecs_t msec, const samples_t sampleRate) const;

--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -314,6 +314,12 @@ struct AudioDevice {
 };
 
 using AudioDeviceList = std::vector<AudioDevice>;
+
+enum class RenderMode {
+    Undefined = -1,
+    RealTimeMode,
+    OfflineMode
+};
 }
 
 #endif // MU_AUDIO_AUDIOTYPES_H

--- a/src/framework/audio/internal/soundtracks/soundtrackwriter.cpp
+++ b/src/framework/audio/internal/soundtracks/soundtrackwriter.cpp
@@ -65,7 +65,7 @@ bool SoundTrackWriter::write()
         return false;
     }
 
-    AudioEngine::instance()->setMode(AudioEngine::Mode::OfflineMode);
+    AudioEngine::instance()->setMode(RenderMode::OfflineMode);
 
     m_source->setSampleRate(m_encoderPtr->format().sampleRate);
     m_source->setIsActive(true);
@@ -83,7 +83,7 @@ bool SoundTrackWriter::write()
     m_source->setSampleRate(AudioEngine::instance()->sampleRate());
     m_source->setIsActive(false);
 
-    AudioEngine::instance()->setMode(AudioEngine::Mode::RealTimeMode);
+    AudioEngine::instance()->setMode(RenderMode::RealTimeMode);
 
     return true;
 }

--- a/src/framework/audio/internal/worker/audioengine.h
+++ b/src/framework/audio/internal/worker/audioengine.h
@@ -26,6 +26,7 @@
 
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "async/notification.h"
 #include "types/retval.h"
 
 #include "../../iaudiodriver.h"
@@ -40,12 +41,6 @@ public:
 
     static AudioEngine* instance();
 
-    enum class Mode {
-        Undefined = -1,
-        RealTimeMode,
-        OfflineMode
-    };
-
     Ret init(IAudioBufferPtr bufferPtr);
     void deinit();
 
@@ -54,7 +49,10 @@ public:
     void setSampleRate(unsigned int sampleRate);
     void setReadBufferSize(uint16_t readBufferSize);
     void setAudioChannelsCount(const audioch_t count);
-    void setMode(const Mode newMode);
+
+    RenderMode mode() const;
+    void setMode(const RenderMode newMode);
+    async::Notification modeChanged() const;
 
     MixerPtr mixer() const;
 
@@ -68,7 +66,8 @@ private:
     MixerPtr m_mixer = nullptr;
     IAudioBufferPtr m_buffer = nullptr;
 
-    Mode m_currentMode = Mode::Undefined;
+    RenderMode m_currentMode = RenderMode::Undefined;
+    async::Notification m_modeChanges;
 };
 }
 

--- a/src/framework/mpe/events.h
+++ b/src/framework/mpe/events.h
@@ -49,6 +49,7 @@ struct ArrangementContext
     duration_t nominalDuration = 0;
     duration_t actualDuration = 0;
     voice_layer_idx_t voiceLayerIndex = 0;
+    double/*engraving::BeatsPerSecond*/ bps = 0;
 
     bool operator==(const ArrangementContext& other) const
     {
@@ -56,7 +57,8 @@ struct ArrangementContext
                && actualTimestamp == other.actualTimestamp
                && nominalDuration == other.nominalDuration
                && actualDuration == other.actualDuration
-               && voiceLayerIndex == other.voiceLayerIndex;
+               && voiceLayerIndex == other.voiceLayerIndex
+               && bps == other.bps;
     }
 };
 
@@ -102,11 +104,13 @@ struct NoteEvent
                        const voice_layer_idx_t voiceIdx,
                        const pitch_level_t nominalPitchLevel,
                        const dynamic_level_t nominalDynamicLevel,
-                       const ArticulationMap& articulationsApplied)
+                       const ArticulationMap& articulationsApplied,
+                       const double/*engraving::BeatsPerSecond*/ bps)
     {
         m_arrangementCtx.nominalDuration = nominalDuration;
         m_arrangementCtx.nominalTimestamp = nominalTimestamp;
         m_arrangementCtx.voiceLayerIndex = voiceIdx;
+        m_arrangementCtx.bps = bps;
 
         m_pitchCtx.nominalPitchLevel = nominalPitchLevel;
 

--- a/src/framework/mpe/tests/multinotearticulationstest.cpp
+++ b/src/framework/mpe/tests/multinotearticulationstest.cpp
@@ -121,7 +121,8 @@ TEST_F(Engraving_MultiNoteArticulationsTest, StandardPattern)
                             pair.second.voiceIdx,
                             pair.second.nominalPitchLevel,
                             pair.second.nominalDynamicLevel,
-                            appliedArticulations);
+                            appliedArticulations,
+                            0);
 
         noteEvents.emplace(pair.first, std::move(noteEvent));
     }
@@ -218,7 +219,8 @@ TEST_F(Engraving_MultiNoteArticulationsTest, GlissandoPattern)
                             pair.second.voiceIdx,
                             pair.second.nominalPitchLevel,
                             pair.second.nominalDynamicLevel,
-                            appliedArticulations[pair.first]);
+                            appliedArticulations[pair.first],
+                            0);
 
         noteEvents.emplace(pair.first, std::move(noteEvent));
     }
@@ -300,7 +302,8 @@ TEST_F(Engraving_MultiNoteArticulationsTest, CrescendoPattern)
                             pair.second.voiceIdx,
                             pair.second.nominalPitchLevel,
                             pair.second.nominalDynamicLevel,
-                            appliedArticulations[pair.first]);
+                            appliedArticulations[pair.first],
+                            0);
 
         noteEvents.emplace(pair.first, std::move(noteEvent));
     }

--- a/src/framework/mpe/tests/singlenotearticulationstest.cpp
+++ b/src/framework/mpe/tests/singlenotearticulationstest.cpp
@@ -93,7 +93,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, StandardPattern)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect that expression curve will be using default curve from standard patterns
     EXPECT_EQ(event.expressionCtx().expressionCurve,
@@ -142,7 +143,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, StaccatoPattern)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect the nominal duration of a note to be unchanged
     EXPECT_EQ(event.arrangementCtx().nominalDuration, m_nominalDuration);
@@ -188,7 +190,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, AccentPattern)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect the nominal duration of a note to be unchanged,
     //        since accent doesn't affect any arrangement data
@@ -244,7 +247,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, AccentPattern_Nominal_MezzoForte)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect the nominal duration of a note to be unchanged,
     //        since accent doesn't affect any arrangement data
@@ -314,7 +318,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, PocoTenuto)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect the nominal duration of a note to be unchanged
     EXPECT_EQ(event.arrangementCtx().nominalDuration, m_nominalDuration);
@@ -364,7 +369,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, QuickFall)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect the pitch curve of the note marked by quick fall articulation to be equal to the pitch curve from corresponding pattern
     EXPECT_EQ(event.pitchCtx().pitchCurve, quickFallPattern.pitchPattern.pitchOffsetMap);
@@ -414,7 +420,8 @@ TEST_F(Engraving_SingleNoteArticulationsTest, Scoop)
                     m_voiceIdx,
                     pitchLevel(m_pitchClass, m_octave),
                     m_nominalDynamic,
-                    std::move(appliedArticulations));
+                    std::move(appliedArticulations),
+                    0);
 
     // [THEN] We expect the pitch curve of the note marked by scoop articulation to be equal to the pitch curve from corresponding pattern
     EXPECT_EQ(event.pitchCtx().pitchCurve, scoopPattern.pitchPattern.pitchOffsetMap);

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -61,7 +61,7 @@ typedef struct ms_OutputBuffer
 
 typedef struct ms_DynamicsEvent
 {
-    long _location_ms;
+    long _location_us;
     double _value; // 0.0 - 1.0
 } ms_DynamicsEvent;
 
@@ -119,8 +119,8 @@ enum ms_NoteArticulation : uint64_t
 typedef struct ms_NoteEvent
 {
     int _voice; // 0-3
-    long _location_ms;
-    long _duration_ms;
+    long _location_us;
+    long _duration_us;
     int _pitch; // MIDI pitch
     double _tempo;
     ms_NoteArticulation _articulation;

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -106,7 +106,6 @@ enum ms_NoteArticulation : uint64_t
     ms_NoteArticulation_Diamond = 1LL << 35,
     ms_NoteArticulation_Portamento = 1LL << 36,
     ms_NoteArticulation_Pizzicato = 1LL << 37,
-    ms_NoteArticulation_TwoNoteTremolo = 1LL << 38,
     ms_NoteArticulation_Glissando = 1LL << 39,
     ms_NoteArticulation_Pedal = 1LL << 40,
     ms_NoteArticulation_Slur = 1LL << 41,

--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -236,7 +236,7 @@ struct MuseSamplerLibHandler
         startAuditionMode = (ms_MuseSampler_start_audition_mode)dlsym(m_lib, "ms_MuseSampler_start_audition_mode");
         stopAuditionMode = (ms_MuseSampler_stop_audition_mode)dlsym(m_lib, "ms_MuseSampler_stop_audition_mode");
         startAuditionNote = (ms_MuseSampler_start_audition_note)dlsym(m_lib, "ms_MuseSampler_start_audition_note");
-        stopAuditionNote = (ms_MuseSampler_stop_audition_note)dlsym(m_lib, "ms_MuseSampelr_stop_audition_note");
+        stopAuditionNote = (ms_MuseSampler_stop_audition_note)dlsym(m_lib, "ms_MuseSampler_stop_audition_note");
 
         startLivePlayMode = (ms_MuseSampler_start_liveplay_mode)dlsym(m_lib, "ms_MuseSampler_start_liveplay_mode");
         stopLivePlayMode = (ms_MuseSampler_stop_liveplay_mode)dlsym(m_lib, "ms_MuseSampler_stop_liveplay_mode");

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -182,7 +182,7 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
     event._location_ms = noteEvent.arrangementCtx().nominalTimestamp / 1000.f; // FIXME Avoid micros -> millis conversion
     event._duration_ms = noteEvent.arrangementCtx().nominalDuration / 1000.f;
     event._pitch = pitchIndex(noteEvent.pitchCtx().nominalPitchLevel);
-    event._tempo = 0.0;
+    event._tempo = noteEvent.arrangementCtx().bps;
     event._articulation = noteArticulationTypes(noteEvent);
 
     for (auto& art : noteEvent.expressionCtx().articulations) {

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -179,8 +179,8 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
 
     ms_NoteEvent event{};
     event._voice = noteEvent.arrangementCtx().voiceLayerIndex;
-    event._location_ms = noteEvent.arrangementCtx().nominalTimestamp / 1000.f; // FIXME Avoid micros -> millis conversion
-    event._duration_ms = noteEvent.arrangementCtx().nominalDuration / 1000.f;
+    event._location_us = noteEvent.arrangementCtx().nominalTimestamp;
+    event._duration_us = noteEvent.arrangementCtx().nominalDuration;
     event._pitch = pitchIndex(noteEvent.pitchCtx().nominalPitchLevel);
     event._tempo = noteEvent.arrangementCtx().bps;
     event._articulation = noteArticulationTypes(noteEvent);
@@ -203,8 +203,8 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
         LOGE() << "Unable to add event for track";
     } else {
         LOGI() << "Successfully added note event, pitch: " << event._pitch
-               << ", timestamp: " << event._location_ms
-               << ", duration: " << event._duration_ms
+               << ", timestamp: " << event._location_us
+               << ", duration: " << event._duration_us
                << ", articulations flag: " << event._articulation;
     }
 

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -182,7 +182,8 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
     event._location_us = noteEvent.arrangementCtx().nominalTimestamp;
     event._duration_us = noteEvent.arrangementCtx().nominalDuration;
     event._pitch = pitchIndex(noteEvent.pitchCtx().nominalPitchLevel);
-    event._tempo = noteEvent.arrangementCtx().bps;
+    // API expects BPM
+    event._tempo = noteEvent.arrangementCtx().bps * 60.0;
     event._articulation = noteArticulationTypes(noteEvent);
 
     for (auto& art : noteEvent.expressionCtx().articulations) {

--- a/src/framework/musesampler/internal/musesamplersequencer.h
+++ b/src/framework/musesampler/internal/musesamplersequencer.h
@@ -65,6 +65,9 @@ public:
 private:
     void reloadTrack();
 
+    void loadNoteEvents(const mpe::PlaybackEventsMap& changes);
+    void loadDynamicEvents(const mpe::DynamicLevelMap& changes);
+
     void addNoteEvent(const mpe::NoteEvent& noteEvent);
     int pitchIndex(const mpe::pitch_level_t pitchLevel) const;
     double dynamicLevelRatio(const mpe::dynamic_level_t level) const;

--- a/src/framework/musesampler/internal/musesamplerutils.h
+++ b/src/framework/musesampler/internal/musesamplerutils.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_MUSESAMPLER_UTILS_H
+#define MU_MUSESAMPLER_UTILS_H
+
+#include <string>
+#include <optional>
+
+namespace mu::musesampler {
+
+// Format of stored ID:
+// CATEGORY\NAME\UNIQUE ID
+
+inline static std::optional<std::string> getMuseInstrumentCategoryFromId(const std::string& id)
+{
+    if (auto pos = id.find_first_of('\\'); pos != std::string::npos) 
+        return id.substr(0, pos);
+    return std::nullopt;
+}
+
+inline static std::optional<std::string> getMuseInstrumentNameFromId(const std::string& id)
+{
+    auto start = id.find_first_of('\\');
+    auto end = id.find_last_of('\\');
+    if (start == std::string::npos || end == std::string::npos || start >= end)
+        return std::nullopt;
+
+    return id.substr(start + 1, end - start - 1);
+}
+
+inline static std::optional<int> getMuseInstrumentUniqueIdFromId(const std::string& id)
+{
+    auto pos = id.find_last_of('\\');
+    try {
+        return std::stoi(id.substr(pos + 1));
+    } catch(...) {
+        return std::nullopt;
+    }
+}
+
+inline static std::string buildMuseInstrumentId(const std::string& category, const std::string& name, int unique_id)
+{
+    return category + '\\' + name + '\\' + std::to_string(unique_id);
+}
+
+} // namespace mu::musesampler
+
+#endif // MU_MUSESAMPLER_UTILS_H

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -213,6 +213,21 @@ void MuseSamplerWrapper::setupEvents(const mpe::PlaybackData& playbackData)
     m_sequencer.load(playbackData);
 }
 
+void MuseSamplerWrapper::updateRenderingMode(const audio::RenderMode mode)
+{
+    ONLY_AUDIO_WORKER_THREAD;
+
+    if (!m_samplerLib || !m_sampler) {
+        return;
+    }
+
+    if (mode == audio::RenderMode::OfflineMode) {
+        m_samplerLib->startOfflineMode(m_sampler, m_sampleRate);
+    } else {
+        m_samplerLib->stopOfflineMode(m_sampler);
+    }
+}
+
 msecs_t MuseSamplerWrapper::playbackPosition() const
 {
     return m_sequencer.playbackPosition();

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -51,6 +51,7 @@ public:
 protected:
     void setupSound(const mpe::PlaybackSetupData& setupData) override;
     void setupEvents(const mpe::PlaybackData& playbackData) override;
+    void updateRenderingMode(const audio::RenderMode mode) override;
 
     audio::msecs_t playbackPosition() const override;
     void setPlaybackPosition(const audio::msecs_t newPosition) override;


### PR DESCRIPTION
MuseSampler should always return "success" for compatible resources

(Otherwise instrument switching logic doesn't work, because it is looking for an MPE match...)

Example issue:
-if you have a trumpet, you cannot switch to muse sounds playback of a selected instrument unless you have the muse brass package installed in particular (it fails the resolution check before initializing the new instrument).  This is misleading, since the options remain in the menu.

Instead, we should always allow switching to any of these instruments.