### PR TITLE
"has compatible resources" needs to return true for muse sounds

### DIFF
--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -55,11 +55,7 @@ bool MuseSamplerResolver::hasCompatibleResources(const audio::PlaybackSetupData&
     if (!m_libHandler) {
         return false;
     }
-
-    ByteArray idStr = setup.toString().toUtf8();
-
-    return m_libHandler->containsInstrument(idStr.constChar(),
-                                            setup.musicXmlSoundId->c_str());
+    return true;
 }
 
 AudioResourceMetaList MuseSamplerResolver::resolveResources() const


### PR DESCRIPTION
Compatible resources check:
MuseSampler should always return "success" for compatible resources

(Otherwise instrument switching logic doesn't work, because it is looking for an MPE match...)

Example issue:
-if you have a trumpet, you cannot switch to muse sounds playback of a selected instrument unless you have the muse brass package installed in particular (it fails the resolution check before initializing the new instrument). This is especially misleading, since the options for other instruments remain in the menu.

Instead, we should always allow switching to any of these instruments.