### PR TITLE
Improve check for library validity; rename Windows DLL

### DIFF
--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -252,7 +252,9 @@ struct MuseSamplerLibHandler
         process = (ms_MuseSampler_process)getLibFunc(m_lib, "ms_MuseSampler_process");
         allNotesOff = (ms_MuseSampler_all_notes_off)getLibFunc(m_lib, "ms_MuseSampler_all_notes_off");
 
-        initLib();
+        if (initLib) {
+            initLib();
+        }
     }
 
     ~MuseSamplerLibHandler()

--- a/src/framework/musesampler/internal/musesamplerconfiguration.cpp
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.cpp
@@ -32,7 +32,7 @@ static const io::path_t DEFAULT_PATH("libMuseSamplerCoreLib.so");
 #elif defined(Q_OS_MAC)
 static const io::path_t DEFAULT_PATH("/usr/local/lib/libMuseSamplerCoreLib.dylib");
 #else
-static const io::path_t DEFAULT_PATH("libMuseSamplerCoreLib.dll");
+static const io::path_t DEFAULT_PATH("MuseSamplerCoreLib.dll");
 #endif
 
 io::path_t MuseSamplerConfiguration::libraryPath() const


### PR DESCRIPTION
If library exists, but doesn't have "init" symbol, would crash when loading.  This fixes this issue.

Also changes windows DLL name to a more canonical form.
